### PR TITLE
Fix problem with key escaping in JSON._object

### DIFF
--- a/lib/json.bash
+++ b/lib/json.bash
@@ -98,9 +98,8 @@ JSON.object() {
 JSON._object() {
   local key=$1
   if [[ -n $key && $key != "/" ]]; then
-    key=${key/\//\\/}
-    grep -E "^$key/" |
-    sed "s/^$key//"
+    key=${key//\//\\/}
+    sed -n "s/^$key//p"
   else
     cat
   fi

--- a/test/keys.t
+++ b/test/keys.t
@@ -2,7 +2,7 @@
 
 source test/setup
 
-use Test::More tests 5
+use Test::More tests 6
 use JSON
 
 tree1=$(cat test/keys.json | JSON.load)
@@ -28,3 +28,8 @@ is "$keys" \
 keys="$(JSON.keys '/' tree1)"
 is "$keys" "description"$'\n'"files" \
     "JSON.keys '/'" #'
+
+keys="$(JSON.keys '/files/file 2.txt' tree1)"
+is "$keys" \
+    "content"$'\n'"type" \
+    "JSON.keys '/files/file 2.txt'" #'


### PR DESCRIPTION
When calling JSON.keys or JSON.object with nested key, it fails with sed error `unknown option to 's'`. This is caused by incorrect bash substitution, which escapes only the first slash in key. I added a test which demonstrates this as well.

I also took the liberty to optimize out the grep in JSON._object, which was not really needed...