### PR TITLE
make sorting in test portable

### DIFF
--- a/test/keys.t
+++ b/test/keys.t
@@ -16,13 +16,7 @@ is "$(JSON.get '/files/file 2.txt/type' tree1)" \
 file_object=$(JSON.object '/files' tree1)
 
 # XXX Can't get osx and linux to sort these the same. Workaround:
-{
-  if [[ "$(uname)" == Darwin ]]; then
-    expect="file 2.txt"$'\n'"file1.txt"
-  else
-    expect="file1.txt"$'\n'"file 2.txt"
-  fi
-}
+expect="$(sort <<< "file1.txt"$'\n'"file 2.txt")"
 
 keys="$(JSON.keys '/' file_object)"
 is "$keys" \


### PR DESCRIPTION
Like @dolik-rce suggested in #11, there might be situations where
the same keys are not on adjacent lines.
Instead of hardcoding the expected results in the test, use sort itself.

Couldn't test on osx, though
